### PR TITLE
fix: add missing href attribute to GitHub link in footer component

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -25,7 +25,7 @@ const Footer = () => {
             </a>
           </p>
           <span className="inline-flex sm:ml-auto sm:mt-0 mt-4 justify-center sm:justify-start">
-            <a className="text-gray-500">
+            <a className="text-gray-500" href="https://github.com/jymbocala/deliverease-frontend" target="_blank" rel="noopener noreferrer">
               <svg
                 fill="currentColor"
                 strokeLinecap="round"


### PR DESCRIPTION
Added href link to this github repo when clicking on github logo in footer